### PR TITLE
Remove tpws from DRK

### DIFF
--- a/addons/Trust/data/DRK.lua
+++ b/addons/Trust/data/DRK.lua
@@ -34,7 +34,6 @@ return {
             },
             amws = "Entropy",
             tpws = L{
-                "Cross Reaper"
             }
         },
         SelfBuffs = L{


### PR DESCRIPTION
Having the wrong `tpws` can affect the ability to make a 4 step sc because skillchain_maker will prefer the `tpws`

https://github.com/cyritegamestudios/cylibs/blob/alpha/battle/skillchains/skillchain_maker.lua#L1139-L1140