### PR TITLE
Safe Rolling for COR

### DIFF
--- a/cylibs/entity/jobs/COR.lua
+++ b/cylibs/entity/jobs/COR.lua
@@ -185,7 +185,6 @@ function Corsair:should_double_up(roll_id, roll_num)
 end
 
 function Corsair:can_fold()
-    print(self.roll_mode)
     if self.roll_mode.value == "Safe" then
         return false
     end

--- a/cylibs/entity/jobs/COR.lua
+++ b/cylibs/entity/jobs/COR.lua
@@ -111,9 +111,10 @@ rolls["Avenger's Roll"].Unlucky = 8
 -------
 -- Default initializer for a new Corsair.
 -- @treturn COR A Corsair
-function Corsair.new(action_queue)
+function Corsair.new(action_queue, roll_mode)
     local self = setmetatable(Job.new(), Corsair)
     self.action_queue = action_queue
+    self.roll_mode = roll_mode
     return self
 end
 
@@ -168,13 +169,13 @@ function Corsair:should_double_up(roll_id, roll_num)
     if roll_num == 11 then
         return false
     end
-    if self:is_snake_eye_active() then
-        return true
-    end
     if self:is_lucky_roll(roll_id, roll_num) then
         return false
     end
     if self:is_unlucky_roll(roll_id, roll_num) then
+        return true
+    end
+    if self:is_snake_eye_active() then
         return true
     end
     if roll_num > 5 and not self:can_fold() then
@@ -184,6 +185,11 @@ function Corsair:should_double_up(roll_id, roll_num)
 end
 
 function Corsair:can_fold()
+    print(self.roll_mode)
+    if self.roll_mode.value == "Safe" then
+        return false
+    end
+
     return job_util.knows_job_ability(job_util.job_ability_id('Fold')) == true
         and job_util.can_use_job_ability('Fold')
 end

--- a/cylibs/trust/data/COR.lua
+++ b/cylibs/trust/data/COR.lua
@@ -14,7 +14,7 @@ local Roller = require('cylibs/trust/roles/roller')
 local Shooter = require('cylibs/trust/roles/shooter')
 
 function CorsairTrust.new(settings, action_queue, battle_settings, trust_settings)
-	local job = Corsair.new(action_queue)
+	local job = Corsair.new(action_queue, state.AutoRollMode)
 	local roles = S{
 		Dispeler.new(action_queue, L{}, L{ JobAbility.new('Dark Shot') }, false),
 		Shooter.new(action_queue, trust_settings.Shooter.Delay or 1.5),

--- a/cylibs/trust/roles/roller.lua
+++ b/cylibs/trust/roles/roller.lua
@@ -4,9 +4,10 @@ local Event = require('cylibs/events/Luvent')
 local Roller = setmetatable({}, {__index = Role })
 Roller.__index = Roller
 
-state.AutoRollMode = M{['description'] = 'Auto Roll Mode', 'Manual', 'Auto', 'Off'}
+state.AutoRollMode = M{['description'] = 'Auto Roll Mode', 'Manual', 'Auto', 'Safe', 'Off'}
 state.AutoRollMode:set_description('Manual', "Okay, you do the first roll and I'll double up on my own.")
-state.AutoRollMode:set_description('Auto', "Okay, I'll roll on my own.")
+state.AutoRollMode:set_description('Auto', "Okay, I'll roll on my own and chase 11s.")
+state.AutoRollMode:set_description('Safe', "Okay, I'll roll on my own and try not to bust.")
 
 -- Event called when rolls begin
 function Roller:on_rolls_begin()
@@ -157,7 +158,7 @@ function Roller:check_rolls()
         return
     end
 
-    if state.AutoRollMode.value == 'Auto' then
+    if state.AutoRollMode.value == 'Auto' or state.AutoRollMode.value == 'Safe' then
         if self.job:can_roll() then
             local roll1 = res.job_abilities:with('en', self.roll1:get_roll_name())
             if not self.job:has_roll(roll1.id) then

--- a/ui/settings/menus/rolls/RollSettingsMenuItem.lua
+++ b/ui/settings/menus/rolls/RollSettingsMenuItem.lua
@@ -79,6 +79,7 @@ function RollSettingsMenuItem:getModesMenuItem()
     local rollModesMenuItem = MenuItem.new(L{
         ButtonItem.default('Manual', 18),
         ButtonItem.default('Auto', 18),
+        ButtonItem.default('Safe', 18),
         ButtonItem.default('Off', 18),
     }, L{
         Manual = MenuItem.action(function()
@@ -87,6 +88,9 @@ function RollSettingsMenuItem:getModesMenuItem()
         Auto = MenuItem.action(function()
             handle_set('AutoRollMode', 'Auto')
         end, "Rolling", state.AutoRollMode:get_description('Auto')),
+        Safe = MenuItem.action(function()
+            handle_set('AutoRollMode', 'Safe')
+        end, "Rolling", state.AutoRollMode:get_description('Safe')),
         Off = MenuItem.action(function()
             handle_set('AutoRollMode', 'Off')
         end, "Rolling", state.AutoRollMode:get_description('Off')),


### PR DESCRIPTION
The current rolling logic will chase for 11s as long as fold is up and that's fine for EPing,. For any content that is more fast paced, that considerably slows down the runs.

I've tested this code for a week through Sortie mostly and the busts have been almost non-existent.