### PR TITLE
spell_util changes

### DIFF
--- a/cylibs/trust/roles/sleeper.lua
+++ b/cylibs/trust/roles/sleeper.lua
@@ -63,7 +63,7 @@ function Sleeper:check_sleep()
 
     if mobs_to_sleep:length() >= self.min_mobs_to_sleep then
         for sleep_spell in self.sleep_spells:it() do
-            if spell_util.get_spell_recast(sleep_spell:get_spell().id) == 0 then
+            if not spell_util.is_spell_on_cooldown(sleep_spell:get_spell().id) then
                 self:cast_spell(sleep_spell, mobs_to_sleep[1].index)
                 return
             end

--- a/cylibs/util/spell_util.lua
+++ b/cylibs/util/spell_util.lua
@@ -182,24 +182,7 @@ end
 -- @tparam number spell_id Spell id (see spells.lua)
 -- @treturn Boolean True if the player knows the spell and its recast timer is up.
 function spell_util.can_cast_spell(spell_id)
-    return spell_util.get_spell_recast(spell_id) == 0 and spell_util.knows_spell(spell_id)
-end
-
--------
--- Returns the spell recast for the given spell. Note that this will return 0 if a player has learned a spell but
--- does not have access to it on their current job.
--- @tparam number spell_id Spell id (see spells.lua)
--- @treturn number Recast time (in seconds)
-function spell_util.get_spell_recast(spell_id)
-    -- Honor March
-    if spell_id == 417 then return 0 end
-
-    local all_spells = windower.ffxi.get_spells()
-    local recast_times = windower.ffxi.get_spell_recasts()
-
-    if not all_spells[spell_id] then return 9999 end
-
-    return recast_times[spell_id]
+    return spell_util.knows_spell(spell_id) and windower.ffxi.get_spell_recasts()[spell_id] == 0
 end
 
 -------
@@ -207,8 +190,7 @@ end
 -- @tparam number spell_id Spell id (see spells.lua)
 -- @treturn boolean Whether the spell is on cooldown.
 function spell_util.is_spell_on_cooldown(spell_id)
-    local recast_time = spell_util.get_spell_recast(spell_id)
-    return recast_time > 0
+    return windower.ffxi.get_spell_recasts()[spell_id] > 0
 end
 
 -------

--- a/cylibs/util/spell_util.lua
+++ b/cylibs/util/spell_util.lua
@@ -18,7 +18,8 @@ _libs.spell_util = spell_util
 
 -- Spells that come from things like items
 local spells_whitelist = L{
-    'Honor March'
+    'Honor March', 'Aria of Passion',
+    'Dispelga', 'Impact'
 }
 
 local aoe_spells = L{


### PR DESCRIPTION
The `spell_utils.get_spell_recast` function was doing a redundant check to see if the spell was unknown/unlearned, so I removed it and used `windower.ffxi.get_spell_recasts()` in it's place. This has the added benefit of not needing a second spell whitelist, which was also returning incorrect recast timers for those spells.

These changes will *not change* the behavior of `spell_util.can_cast_spell`, but *will change* `spell_util.is_spell_on_cooldown`. Previously it would always return `true` for unknown/unlearned spells, implying that it is on cooldown, which is not correct.

**From what i can tell, the current uses of `spell_util.is_spell_on_cooldown` should not be effected by the new behavior. But this should get some review/testing.**

I also added Aria of Passion, Dispelga and Impact to the whitelisted spells.