### PR TITLE
Fix tostring parse issue in ready_move_action.lua

### DIFF
--- a/cylibs/actions/ready_move_action.lua
+++ b/cylibs/actions/ready_move_action.lua
@@ -75,8 +75,9 @@ function ReadyMoveAction:is_equal(action)
     return self:gettype() == action:gettype() and self:get_ready_move_name() == action:get_ready_move_name()
 end
 
+-- Fixed tostring method
 function ReadyMoveAction:tostring()
-    return "ReadyMoveAction command: %s":format(self.command)
+    return "ReadyMoveAction command: %s":format(self.ready_move_name)
 end
 
 return ReadyMoveAction


### PR DESCRIPTION
As the title suggests, fixes the tostring parsing to actually parse for the proper function.

