### PR TITLE
Remove velocity shot

### DIFF
--- a/data/RNG.lua
+++ b/data/RNG.lua
@@ -13,7 +13,6 @@ return {
 
         },
         JobAbilities = L{
-            JobAbility.new('Velocity Shot', L{InBattleCondition.new()}),
         },
         PullSettings = {
             Abilities = L{


### PR DESCRIPTION
in an EP setting, RNG is most likely going to be spamming Savage Blade due to inventory filling up for most users. Relying on Gearswap to create arrows is also not reliable since the user might run out of arrows in a long EP session.

my dmg went from 3.5k DPS to 7k DPS by removing Velocity shot in the same party makeup.