### PR TITLE
fix job conditions

### DIFF
--- a/data/GEO.lua
+++ b/data/GEO.lua
@@ -6,8 +6,8 @@ return {
 
         },
         PartyBuffs = L{
-            Spell.new("Indi-STR", L{"Entrust"}, L{}, nil, L{JobCondition.new("DRK", "SAM", "WAR", "MNK")}),
-            Spell.new("Indi-Fury", L{"Entrust"}, L{}, nil, L{JobCondition.new("RUN")})
+            Spell.new("Indi-STR", L{"Entrust"}, L{}, nil, L{JobCondition.new(L{"DRK", "SAM", "WAR", "MNK"})}),
+            Spell.new("Indi-Fury", L{"Entrust"}, L{}, nil, L{JobCondition.new(L{"RUN"})})
         },
         NukeSettings = {
             Delay = 4,

--- a/data/SCH.lua
+++ b/data/SCH.lua
@@ -4,7 +4,7 @@ return {
     Default = {
         LightArts = {
             PartyBuffs = L{
-                Spell.new("Adloquium", L{}, L{}, nil, L{JobCondition.new("WAR", "DRK", "DRG")})
+                Spell.new("Adloquium", L{}, L{}, nil, L{JobCondition.new(L{"WAR", "DRK", "DRG"})})
             },
             SelfBuffs = L{
                 JobAbility.new('Light Arts', L{}, L{}, nil),

--- a/data/WHM.lua
+++ b/data/WHM.lua
@@ -33,9 +33,9 @@ return {
             Overcure = false
         },
         PartyBuffs = L{
-            Buff.new("Haste", L{}, L{}, nil, L{JobCondition.new("WAR", "MNK", "THF", "PLD", "DRK", "SAM", "DRG", "NIN", "PUP", "COR", "DNC", "BLU", "RUN", "BLM", "BRD", "BST")}),
-            Buff.new("Protect", L{}, L{}, nil, L{JobCondition.new("WAR", "WHM", "RDM", "PLD", "BRD", "SAM", "DRG", "BLU", "PUP", "SCH", "RUN", "MNK", "BLM", "THF", "BST", "RNG", "NIN", "SMN", "COR", "DNC", "GEO", "DRK")}),
-            Buff.new("Shell", L{}, L{}, nil, L{JobCondition.new("WAR", "WHM", "RDM", "PLD", "BRD", "SAM", "DRG", "BLU", "PUP", "SCH", "RUN", "MNK", "BLM", "THF", "BST", "RNG", "NIN", "SMN", "COR", "DNC", "GEO", "DRK")})
+            Buff.new("Haste", L{}, L{}, nil, L{JobCondition.new(L{"WAR", "MNK", "THF", "PLD", "DRK", "SAM", "DRG", "NIN", "PUP", "COR", "DNC", "BLU", "RUN", "BLM", "BRD", "BST"})}),
+            Buff.new("Protect", L{}, L{}, nil, L{JobCondition.new(L{"WAR", "WHM", "RDM", "PLD", "BRD", "SAM", "DRG", "BLU", "PUP", "SCH", "RUN", "MNK", "BLM", "THF", "BST", "RNG", "NIN", "SMN", "COR", "DNC", "GEO", "DRK"})}),
+            Buff.new("Shell", L{}, L{}, nil, L{JobCondition.new(L{"WAR", "WHM", "RDM", "PLD", "BRD", "SAM", "DRG", "BLU", "PUP", "SCH", "RUN", "MNK", "BLM", "THF", "BST", "RNG", "NIN", "SMN", "COR", "DNC", "GEO", "DRK"})})
         },
         NukeSettings = {
             Delay = 10,


### PR DESCRIPTION
In a few of the default configurations, a new JobCondition was being giving individual strings as different parameters instead of a list as a single parameter.