### PR TITLE
Change BRD AutoFollowMode while singing

### DIFF
--- a/cylibs/actions/job_ability.lua
+++ b/cylibs/actions/job_ability.lua
@@ -42,6 +42,11 @@ function JobAbility:perform()
 
     local target = windower.ffxi.get_mob_by_index(self.target_index or windower.ffxi.get_player().index)
 
+    if target == nil then
+        self:complete(false)
+        return
+    end
+
     local command = JobAbilityCommand.new(self.job_ability_name, target.id)
     command:run(true)
 
@@ -86,10 +91,10 @@ end
 
 function JobAbility:tostring()
     local target = windower.ffxi.get_mob_by_index(self.target_index or windower.ffxi.get_player().index)
-    if target.name == windower.ffxi.get_player().name then
-       return self:get_job_ability_name()
+    if target and target.name == windower.ffxi.get_player().name then
+        return self:get_job_ability_name()
     end
-    return i18n.resource('job_abilities', 'en', self:get_job_ability_name()) or self:get_job_ability_name()..' → '..target.name
+    return i18n.resource('job_abilities', 'en', self:get_job_ability_name()) or self:get_job_ability_name()..' → '..(target.name or '')
 end
 
 function JobAbility:debug_string()

--- a/cylibs/modes/mode_delta.lua
+++ b/cylibs/modes/mode_delta.lua
@@ -32,7 +32,9 @@ function ModeDelta:apply(hideHelpText)
     self.disposeBag:dispose()
     self.disposeBag:add(on_state_changed():addAction(function(modeName, modeValue)
         self.oldModes[modeName] = modeValue
-        addon_system_error(self.errorMessage)
+        if not self.whitelist:contains(modeName) then
+            addon_system_error(self.errorMessage)
+        end
     end), on_state_changed())
 end
 

--- a/cylibs/trust/data/BRD.lua
+++ b/cylibs/trust/data/BRD.lua
@@ -45,7 +45,7 @@ function BardTrust.new(settings, action_queue, battle_settings, trust_settings, 
 	state.SongSet:options(L(T(trust_settings.SongSettings.SongSets):keyset()):unpack())
 	self.num_songs = trust_settings.NumSongs
 	self.action_queue = action_queue
-	self.song_modes_delta = ModeDelta.new(BardModes.Singing, "Unable to change modes while singing. Use // trust stop to stop singing.", S{ 'AutoSongMode' })
+	self.song_modes_delta = ModeDelta.new(BardModes.Singing, "Unable to change modes while singing. Use // trust stop to stop singing.", S{ 'AutoSongMode', 'AutoFollowMode' })
 
 	return self
 end


### PR DESCRIPTION
Added AutoFollowMode to BRD
fixed a bug where whitelisted modes cause an error message
fixed a bug where loosing targets while performing actions cause error msg.