### PR TITLE
Fix max melee calculation to include z-height.

### DIFF
--- a/cylibs/actions/runto.lua
+++ b/cylibs/actions/runto.lua
@@ -103,7 +103,8 @@ function RunToAction:target_distance()
 		return 0
 	end
 
-	return target.distance:sqrt()
+	-- Update to use geometry_util.xyz_accurate_distance because the game actually does care about z-axis.
+	return geometry_util.xyz_accurate_distance(target, windower.ffxi.get_mob_by_id(windower.ffxi.get_player().id))
 end
 
 function RunToAction:gettype()
@@ -130,6 +131,3 @@ function RunToAction:tostring()
 end
 
 return RunToAction
-
-
-

--- a/cylibs/trust/roles/combat_mode.lua
+++ b/cylibs/trust/roles/combat_mode.lua
@@ -110,10 +110,13 @@ function CombatMode:check_distance()
                     end
                 end
             else
-                if target.distance:sqrt() > self.melee_distance + self_mob.model_size + target.model_size - 0.2 then
+                -- Aldros: Update to use geometry_util.xyz_accurate_distance because the game actually does care about z-axis.
+                -- We also subtract 0.2 just in case... This may not be needed now with the new distance check.
+                -- I've also never seen model_scale be anything other than 1.0, buuuut can't hurt to have it.
+                if geometry_util.xyz_accurate_distance(target, self_mob) > self.melee_distance + (self_mob.model_size * self_mob.model_scale) + (target.model_size * target.model_scale) - 0.2 then
                     self.action_queue:push_action(BlockAction.new(function() player_util.face(target) end))
                     self.action_queue:push_action(
-                        RunToAction.new(target.index, self.melee_distance + self_mob.model_size + target.model_size - 0.2),
+                        RunToAction.new(target.index, self.melee_distance + (self_mob.model_size * self_mob.model_scale) + (target.model_size * target.model_scale) - 0.2),
                         true)
                 else
                     self:face_target(target)

--- a/cylibs/util/geometry_util.lua
+++ b/cylibs/util/geometry_util.lua
@@ -94,6 +94,16 @@ function geometry_util.is_in_front(target)
 	return math.abs((target.facing - player.facing) - math.pi) < (math.pi / 12.0)
 end
 
+-------
+-- Returns the distance between two mobs, including the z-axis.
+-- @tparam MobMetadata target Target mob
+-- @tparam MobMetadata self Self mob
+-- @treturn number Distance in yalms
+function geometry_util.xyz_accurate_distance(target, self)
+	local x = target.x - self.x
+	local y = target.y - self.y
+	local z = target.z - self.z
+	return math.sqrt(x*x + y*y + z*z)
+end
+
 return geometry_util
-
-


### PR DESCRIPTION
There was one unsquashed bug I discovered during testing last time I played. On sloped surfaces, there's an edge case that can result in being out of range, which has to do with the z-height issue. This patch addresses it by making the check take into account z-height, and also by having the RunTo action take into account z-height as well. I also threw in the model_scale factor, just for good measure though I've never seen it ever be anything other than 1.0, but knowing FFXI, there's an edge case somewhere.

Hopefully this squashes the out of range bugs for good.