### PR TITLE
Fix subtargeting logic when connected via IPC.

### DIFF
--- a/cylibs/entity/party/party_target.lua
+++ b/cylibs/entity/party/party_target.lua
@@ -1,5 +1,7 @@
 local DisposeBag = require('cylibs/events/dispose_bag')
 local Event = require('cylibs/events/Luvent')
+local IpcRelay = require('cylibs/messages/ipc/ipc_relay')
+local TargetChangeMessage = require('cylibs/messages/target_change_message')
 
 local PartyTarget = {}
 PartyTarget.__index = PartyTarget
@@ -73,6 +75,7 @@ function PartyTarget:log_target_changed(old_target_index, new_target_index)
 end
 
 function PartyTarget:set_target_index(target_index)
+    if windower.ffxi.get_mob_by_target('st') then return end
     if self.target_index == target_index then
         return
     end

--- a/cylibs/entity/player.lua
+++ b/cylibs/entity/player.lua
@@ -148,7 +148,7 @@ end
 
 function Player:update_target(target_index)
     if self.target_index ~= target_index then
-        if target_index and target_index ~= 0 and battle_util.is_valid_monster_target(ffxi_util.mob_id_for_index(target_index)) then
+        if target_index and target_index ~= 0 and battle_util.is_valid_monster_target(ffxi_util.mob_id_for_index(target_index)) and not windower.ffxi.get_mob_by_target('st') then
             local target = windower.ffxi.get_mob_by_index(target_index)
             if target and battle_util.is_valid_monster_target(target.id) then
                 self.target_index = target.index

--- a/cylibs/messages/ipc/ipc_relay.lua
+++ b/cylibs/messages/ipc/ipc_relay.lua
@@ -8,6 +8,7 @@ local LampUpdateMessage = require('cylibs/messages/lamp_update_message')
 local logger = require('cylibs/logger/logger')
 local LoseBuffMessage = require('cylibs/messages/lose_buff_message')
 local MobUpdateMessage = require('cylibs/messages/mob_update_message')
+local TargetChangeMessage = require('cylibs/messages/target_change_message')
 local ZoneMessage = require('cylibs/messages/zone_message')
 
 local IpcRelay = {}
@@ -57,6 +58,8 @@ function IpcRelay.new()
                     self:on_message_received():trigger(EquipmentChangedMessage.deserialize(message))
                 elseif message_type == 'lamp_update' then
                     self:on_message_received():trigger(LampUpdateMessage.deserialize(message))
+                elseif message_type == 'target_change' then
+                    self:on_message_received():trigger(TargetChangeMessage.deserialize(message))
                 end
             end
         end

--- a/cylibs/messages/target_change_message.lua
+++ b/cylibs/messages/target_change_message.lua
@@ -1,0 +1,42 @@
+local IpcMessage = require('cylibs/messages/ipc_message')
+
+local TargetChangeMessage = setmetatable({}, {__index = IpcMessage })
+TargetChangeMessage.__index = TargetChangeMessage
+TargetChangeMessage.__class = "TargetChangeMessage"
+
+function TargetChangeMessage.new(player_name, target_index)
+    local self = setmetatable(IpcMessage.new(), TargetChangeMessage)
+
+    self.player_name = player_name
+    self.target_index = tonumber(target_index or 0)
+
+    return self
+end
+
+function TargetChangeMessage:get_command()
+    return "target_change"
+end
+
+function TargetChangeMessage:get_player_name()
+    return self.player_name
+end
+
+function TargetChangeMessage:get_target_index()
+    return self.target_index
+end
+
+function TargetChangeMessage:serialize()
+    return "%s %s %d":format(self:get_command(), self:get_player_name(), self:get_target_index())
+end
+
+function TargetChangeMessage.deserialize(message)
+    local ipc_message = IpcMessage.new(message)
+
+    return TargetChangeMessage.new(ipc_message:get_args()[2], ipc_message:get_args()[3])
+end
+
+function TargetChangeMessage:tostring()
+    return "TargetChangeMessage %s":format(self:get_message())
+end
+
+return TargetChangeMessage


### PR DESCRIPTION
This changes the subtarget logic to use an IPC message when the assist target is connected via IPC. This allows us to prevent subtargeting from automatically switching the target so tabbing around with subtarget won't cause your Trusts to run off to attack stuff in the distance.