### PR TITLE
Add support for pulling by target ID

### DIFF
--- a/cylibs/conditions/target_ids.lua
+++ b/cylibs/conditions/target_ids.lua
@@ -1,0 +1,44 @@
+---------------------------
+-- Condition checking the target's id.
+-- @class module
+-- @name TargetIdsCondition
+
+local serializer_util = require('cylibs/util/serializer_util')
+
+local Condition = require('cylibs/conditions/condition')
+local TargetIdsCondition = setmetatable({}, { __index = Condition })
+TargetIdsCondition.__index = TargetIdsCondition
+TargetIdsCondition.__class = "TargetIdsCondition"
+TargetIdsCondition.__type = "TargetIdsCondition"
+
+function TargetIdsCondition.new(ids)
+    local self = setmetatable(Condition.new(), TargetIdsCondition)
+    self.ids = ids or L{}
+    return self
+end
+
+function TargetIdsCondition:is_satisfied(target_index)
+    local target = windower.ffxi.get_mob_by_index(target_index)
+    if target then
+        return self.ids:contains(target.id)
+    end
+    return false
+end
+
+function TargetIdsCondition:tostring()
+    return "Target id "..localization_util.commas(self.ids:map(function(id) return string.format("%X", id) end), 'or')
+end
+
+function TargetIdsCondition.description()
+    return "Targeting mob with id."
+end
+
+function TargetIdsCondition.valid_targets()
+    return S{ Condition.TargetType.Self, Condition.TargetType.Enemy, Condition.TargetType.Ally }
+end
+
+function TargetIdsCondition:serialize()
+    return "TargetIdsCondition.new(" .. serializer_util.serialize_args(self.ids) .. ")"
+end
+
+return TargetIdsCondition

--- a/cylibs/trust/roles/puller.lua
+++ b/cylibs/trust/roles/puller.lua
@@ -12,6 +12,7 @@ local PartyClaimedCondition = require('cylibs/conditions/party_claimed')
 local PartyLeaderCondition = require('cylibs/conditions/party_leader')
 local PartyTargetedCondition = require('cylibs/conditions/party_targeted')
 local RunToLocationAction = require('cylibs/actions/runtolocation')
+local TargetIdsCondition = require('cylibs/conditions/target_ids')
 local TargetNamesCondition = require('cylibs/conditions/target_names')
 
 local Gambiter = require('cylibs/trust/roles/gambiter')
@@ -166,7 +167,7 @@ function Puller:get_all_targets()
         all_targets = sort_bucket(self.mob_filter:get_aggroed_mobs(L{ MobFilter.Type.PartyClaimed }))
                 + sort_bucket(self.mob_filter:get_aggroed_mobs(L{ MobFilter.Type.Unclaimed }))
                 + sort_bucket(self.mob_filter:get_nearby_mobs(L{ MobFilter.Type.Unclaimed }):filter(function(mob)
-            return self.target_names:contains(mob.name)
+            return self.target_names:contains(mob.name) or self.target_ids:contains(mob.id)
         end))
     elseif state.AutoPullMode.value == 'All' then
         -- 1. All mobs that are party claimed
@@ -260,6 +261,7 @@ function Puller:set_pull_settings(pull_settings)
         self.max_num_targets = 1
     end
     self:set_target_names(pull_settings.Targets or L{})
+    self:set_target_ids(pull_settings.TargetIds or L{})
 
     CooldownCondition.set_timestamp('last_mob_ko', os.time() - self.delay)
 
@@ -309,7 +311,10 @@ function Puller:get_default_conditions(gambit)
     if state.AutoPullMode.value == 'Aggroed' then
         conditions:append(GambitCondition.new(AggroedCondition.new(), GambitTarget.TargetType.Enemy))
     elseif state.AutoPullMode.value == 'Auto' then
-        conditions:append(GambitCondition.new(TargetNamesCondition.new(self:get_target_names()), GambitTarget.TargetType.Enemy))
+        conditions:append(GambitCondition.new(ConditionalCondition.new(L{
+            TargetNamesCondition.new(self:get_target_names()),
+            TargetIdsCondition.new(self:get_target_ids()),
+        }, Condition.LogicalOperator.Or), GambitTarget.TargetType.Enemy))
     end
     local alter_ego_conditions = L{
         GambitCondition.new(ConditionalCondition.new(
@@ -339,6 +344,14 @@ end
 
 function Puller:get_target_names()
     return self.target_names
+end
+
+function Puller:set_target_ids(target_ids)
+    self.target_ids = target_ids
+end
+
+function Puller:get_target_ids()
+    return self.target_ids
 end
 
 function Puller:set_camp_position(position)

--- a/cylibs/trust/roles/puller.lua
+++ b/cylibs/trust/roles/puller.lua
@@ -11,6 +11,7 @@ local MobFilter = require('cylibs/battle/monsters/mob_filter')
 local PartyClaimedCondition = require('cylibs/conditions/party_claimed')
 local PartyLeaderCondition = require('cylibs/conditions/party_leader')
 local PartyTargetedCondition = require('cylibs/conditions/party_targeted')
+local PullTargetUtil = require('cylibs/util/pull_target_util')
 local RunToLocationAction = require('cylibs/actions/runtolocation')
 local TargetIdsCondition = require('cylibs/conditions/target_ids')
 local TargetNamesCondition = require('cylibs/conditions/target_names')
@@ -261,7 +262,7 @@ function Puller:set_pull_settings(pull_settings)
         self.max_num_targets = 1
     end
     self:set_target_names(pull_settings.Targets or L{})
-    self:set_target_ids(pull_settings.TargetIds or L{})
+    self:set_target_ids((pull_settings.TargetIds or L{}):map(PullTargetUtil.get_id))
 
     CooldownCondition.set_timestamp('last_mob_ko', os.time() - self.delay)
 

--- a/cylibs/util/pull_target_util.lua
+++ b/cylibs/util/pull_target_util.lua
@@ -1,0 +1,77 @@
+---------------------------
+-- Utility functions for pull targets.
+--
+-- Pull targets are stored in PullSettings.TargetIds as { Id = number, Name = string }.
+-- The name is persisted so it can still be displayed when the mob isn't in the
+-- current zone and can no longer be looked up by id.
+--
+-- @class module
+-- @name PullTargetUtil
+
+_libs = _libs or {}
+
+require('lists')
+
+local pull_target_util = {}
+
+_raw = _raw or {}
+
+_libs.pull_target_util = pull_target_util
+
+-------
+-- Returns the name of the mob with the given id.
+-- @tparam number targetId Mob id.
+-- @treturn string Mob name, or nil if the mob isn't in the current zone.
+function pull_target_util.get_mob_name(targetId)
+    local mob = windower.ffxi.get_mob_by_id(targetId)
+    if mob and mob.name and mob.name ~= '' then
+        return mob.name
+    end
+    return nil
+end
+
+-------
+-- Creates a new pull target.
+-- @tparam number targetId Mob id.
+-- @tparam string targetName (optional) Mob name, resolved from the current zone if omitted.
+-- @treturn table The new pull target.
+function pull_target_util.new(targetId, targetName)
+    return {
+        Id = targetId,
+        Name = targetName or pull_target_util.get_mob_name(targetId)
+    }
+end
+
+-------
+-- Returns the mob id of a pull target.
+-- @tparam table target Pull target.
+-- @treturn number Mob id.
+function pull_target_util.get_id(target)
+    return target.Id
+end
+
+-------
+-- Returns the saved mob name of a pull target.
+-- @tparam table target Pull target.
+-- @treturn string Mob name, or nil if one hasn't been saved.
+function pull_target_util.get_name(target)
+    if target == nil then
+        return nil
+    end
+    return target.Name
+end
+
+-------
+-- Updates the saved name of a pull target if its mob is in the current zone.
+-- @tparam table target Pull target.
+-- @treturn boolean True if the name changed.
+function pull_target_util.update_name(target)
+    local mobName = pull_target_util.get_mob_name(target.Id)
+    if mobName and target.Name ~= mobName then
+        target.Name = mobName
+        return true
+    end
+    return false
+end
+
+return pull_target_util

--- a/settings/migrations/Migrations-Include.lua
+++ b/settings/migrations/Migrations-Include.lua
@@ -1354,6 +1354,36 @@ function Migration_v39:getDescription()
     return "Add pull blacklist."
 end
 
+---------------------------
+-- Adds TargetIds to pull settings.
+-- @class module
+-- @name Migration_v40
+
+local Migration_v40 = setmetatable({}, { __index = Migration })
+Migration_v40.__index = Migration_v40
+Migration_v40.__class = "Migration_v40"
+
+function Migration_v40.new()
+    local self = setmetatable(Migration.new(), Migration_v40)
+    return self
+end
+
+function Migration_v40:shouldPerform(trustSettings, _, _)
+    return trustSettings:getSettings().Default.PullSettings.TargetIds == nil
+end
+
+function Migration_v40:perform(trustSettings, _, _)
+    local modeNames = list.subtract(L(T(trustSettings:getSettings()):keyset()), L{'Version','Migrations'})
+    for modeName in modeNames:it() do
+        local currentSettings = trustSettings:getSettings()[modeName].PullSettings
+        currentSettings.TargetIds = L{}
+    end
+end
+
+function Migration_v40:getDescription()
+    return "Add pull target ids."
+end
+
 return {
     Migration_v1 = Migration_v1,
     Migration_v2 = Migration_v2,
@@ -1392,5 +1422,6 @@ return {
     Migration_v37 = Migration_v37,
     Migration_v38 = Migration_v38,
     Migration_v39 = Migration_v39,
+    Migration_v40 = Migration_v40,
 }
 

--- a/settings/migrations/migration_manager.lua
+++ b/settings/migrations/migration_manager.lua
@@ -48,6 +48,7 @@ function MigrationManager.new(trustSettings, addonSettings, weaponSkillSettings)
         M.Migration_v37.new(),
         M.Migration_v38.new(),
         M.Migration_v39.new(),
+        M.Migration_v40.new(),
         UpdateDefaultGambits.new(),
     }
     return self

--- a/ui/settings/menus/pulling/PullSettingsMenuItem.lua
+++ b/ui/settings/menus/pulling/PullSettingsMenuItem.lua
@@ -9,6 +9,7 @@ local MenuItem = require('cylibs/ui/menu/menu_item')
 local ModesMenuItem = require('ui/settings/menus/ModesMenuItem')
 local MultiPickerConfigItem = require('ui/settings/editors/config/MultiPickerConfigItem')
 local PullActionMenuItem = require('ui/settings/menus/pulling/PullActionMenuItem')
+local PullTargetIDsMenuItem = require('ui/settings/menus/pulling/PullTargetIDsMenuItem')
 local PullTargetsMenuItem = require('ui/settings/menus/pulling/PullTargetsMenuItem')
 local TextInputConfigItem = require('ui/settings/editors/config/TextInputConfigItem')
 
@@ -25,6 +26,7 @@ end
 function PullSettingsMenuItem.new(abilities, trust, job_name_short, trust_settings, trust_settings_mode, trust_mode_settings)
     local self = setmetatable(MenuItem.new(L{
         ButtonItem.default('Targets', 18),
+        ButtonItem.default('Target IDs', 18),
         ButtonItem.default('Actions', 18),
         ButtonItem.default('Blacklist', 18),
         ButtonItem.localized('Modes', i18n.translate("Modes")),
@@ -55,6 +57,7 @@ end
 
 function PullSettingsMenuItem:reloadSettings()
     self:setChildMenuItem("Targets", PullTargetsMenuItem.new(self.trust_settings, self.trust_settings_mode))
+    self:setChildMenuItem("Target IDs", PullTargetIDsMenuItem.new(self.trust_settings, self.trust_settings_mode))
     self:setChildMenuItem("Actions", PullActionMenuItem.new(self.trust, self.trust_settings, self.trust_settings_mode))
     self:setChildMenuItem("Blacklist", self:getBlacklistMenuItem())
     self:setChildMenuItem("Modes", self:getModesMenuItem())

--- a/ui/settings/menus/pulling/PullTargetIDsMenuItem.lua
+++ b/ui/settings/menus/pulling/PullTargetIDsMenuItem.lua
@@ -7,16 +7,22 @@ local IndexPath = require('cylibs/ui/collection_view/index_path')
 local MenuItem = require('cylibs/ui/menu/menu_item')
 local MultiPickerConfigItem = require('ui/settings/editors/config/MultiPickerConfigItem')
 
-local PullTargetsMenuItem = setmetatable({}, {__index = MenuItem })
-PullTargetsMenuItem.__index = PullTargetsMenuItem
+local PullTargetIDsMenuItem = setmetatable({}, {__index = MenuItem })
+PullTargetIDsMenuItem.__index = PullTargetIDsMenuItem
 
-function PullTargetsMenuItem.new(trust_settings, trust_settings_mode)
+local function format_target_id(targetId)
+    local mob = windower.ffxi.get_mob_by_id(targetId)
+    local targetName = mob and mob.name or "Unknown"
+    return string.format("%s (%X)", targetName, targetId)
+end
+
+function PullTargetIDsMenuItem.new(trust_settings, trust_settings_mode)
     local self = setmetatable(MenuItem.new(L{
         ButtonItem.default('Add', 18),
         ButtonItem.default('Remove', 18),
         ButtonItem.default('Move Up', 18),
         ButtonItem.default('Move Down', 18),
-    }, {}, nil, "Targets", "Choose which enemies to pull."), PullTargetsMenuItem)
+    }, {}, nil, "Target IDs", "Choose which enemies to pull by id."), PullTargetIDsMenuItem)
 
     self.trust_settings = trust_settings
     self.trust_settings_mode = trust_settings_mode
@@ -29,10 +35,10 @@ function PullTargetsMenuItem.new(trust_settings, trust_settings_mode)
     self:setChildMenuItem("Move Down", self:getMoveDownMenuItem())
 
     self.contentViewConstructor = function()
-        local currentTargets = self:getTargets()
+        local currentTargetIds = self:getTargetIds()
 
-        local configItem = MultiPickerConfigItem.new("Targets", L{}, currentTargets, function(targetName)
-            return targetName
+        local configItem = MultiPickerConfigItem.new("Target IDs", L{}, currentTargetIds, function(targetId)
+            return format_target_id(targetId)
         end)
 
         self.targetsEditor = FFXIPickerView.new(L{ configItem }, false, FFXIClassicStyle.WindowSize.Editor.ConfigEditor)
@@ -44,44 +50,46 @@ function PullTargetsMenuItem.new(trust_settings, trust_settings_mode)
     return self
 end
 
-function PullTargetsMenuItem:destroy()
+function PullTargetIDsMenuItem:destroy()
     MenuItem.destroy(self)
 
     self.dispose_bag:destroy()
 end
 
-function PullTargetsMenuItem:getTargets()
-    return self.trust_settings:getSettings()[self.trust_settings_mode.value].PullSettings.Targets
+function PullTargetIDsMenuItem:getTargetIds()
+    local pullSettings = self.trust_settings:getSettings()[self.trust_settings_mode.value].PullSettings
+    pullSettings.TargetIds = pullSettings.TargetIds or L{}
+    return pullSettings.TargetIds
 end
 
-function PullTargetsMenuItem:getAddMenuItem()
+function PullTargetIDsMenuItem:getAddMenuItem()
     local chooseTargetsMenuItem = MenuItem.new(L{
         ButtonItem.localized('Confirm', i18n.translate('Button_Confirm')),
         ButtonItem.default('Clear All', 18),
     }, {
-        Clear = MenuItem.action(nil, "Targets", "Clear selected targets."),
+        Clear = MenuItem.action(nil, "Target IDs", "Clear selected targets."),
     },
     function()
-        local allMobs = S{}
+        local allTargetIds = S{}
         local nearbyMobs = windower.ffxi.get_mob_array()
         for _, mob in pairs(nearbyMobs) do
             if mob.valid_target and mob.spawn_type == 16 then
-                allMobs:add(mob.name)
+                allTargetIds:add(mob.id)
             end
         end
 
-        local configItem = MultiPickerConfigItem.new("Targets", L{}, L(allMobs), function(mobName)
-            return mobName
+        local configItem = MultiPickerConfigItem.new("Target IDs", L{}, L(allTargetIds), function(targetId)
+            return format_target_id(targetId)
         end)
 
         local targetPickerView = FFXIPickerView.withConfig(configItem, true, FFXIClassicStyle.WindowSize.Editor.ConfigEditor)
 
-        self.dispose_bag:add(targetPickerView:on_pick_items():addAction(function(_, newTargetNames)
+        self.dispose_bag:add(targetPickerView:on_pick_items():addAction(function(_, newTargetIds)
             targetPickerView:getDelegate():deselectAllItems()
 
-            if newTargetNames:length() > 0 then
+            if newTargetIds:length() > 0 then
                 local pullSettings = self.trust_settings:getSettings()[self.trust_settings_mode.value].PullSettings
-                pullSettings.Targets = L(S(pullSettings.Targets + newTargetNames))
+                pullSettings.TargetIds = L(S(self:getTargetIds() + newTargetIds))
 
                 self.trust_settings:saveSettings(true)
 
@@ -90,22 +98,22 @@ function PullTargetsMenuItem:getAddMenuItem()
         end), targetPickerView:on_pick_items())
 
         return targetPickerView
-    end, "Targets", "Choose which enemies to pull.")
+    end, "Target IDs", "Choose which enemies to pull by id.")
 
     chooseTargetsMenuItem:setChildMenuItem("Confirm", MenuItem.action(function(menu)
         menu:showMenu(self)
-    end, "Targets", "Confirm enemies to pull."))
+    end, "Target IDs", "Confirm enemies to pull."))
 
     return chooseTargetsMenuItem
 end
 
-function PullTargetsMenuItem:getRemoveMenuItem()
+function PullTargetIDsMenuItem:getRemoveMenuItem()
     return MenuItem.action(function()
         if self.targetsEditor then
             local cursorIndexPath = self.targetsEditor:getDelegate():getCursorIndexPath()
             if cursorIndexPath then
-                local currentTargets = self:getTargets()
-                currentTargets:remove(cursorIndexPath.row)
+                local currentTargetIds = self:getTargetIds()
+                currentTargetIds:remove(cursorIndexPath.row)
 
                 self.targetsEditor:getDataSource():removeItem(cursorIndexPath)
 
@@ -114,24 +122,24 @@ function PullTargetsMenuItem:getRemoveMenuItem()
                 addon_message(260, '('..windower.ffxi.get_player().name..') '.."Alright, I won't pull this enemy anymore!")
             end
         end
-    end, "Targets", "Remove selected target from list of enemies to pull.", false, function()
-        return self:getTargets():length() > 0
+    end, "Target IDs", "Remove selected target from list of enemies to pull.", false, function()
+        return self:getTargetIds():length() > 0
     end)
 end
 
-function PullTargetsMenuItem:getMoveUpMenuItem()
+function PullTargetIDsMenuItem:getMoveUpMenuItem()
     return MenuItem.action(function()
         if self.targetsEditor then
             local selectedIndexPath = self.targetsEditor:getDelegate():getCursorIndexPath()
             if selectedIndexPath and selectedIndexPath.row > 1 then
-                local currentTargets = self:getTargets()
+                local currentTargetIds = self:getTargetIds()
                 local row = selectedIndexPath.row
                 local newIndexPath = IndexPath.new(selectedIndexPath.section, row - 1)
 
                 local item1 = self.targetsEditor:getDataSource():itemAtIndexPath(selectedIndexPath)
                 local item2 = self.targetsEditor:getDataSource():itemAtIndexPath(newIndexPath)
                 if item1 and item2 then
-                    currentTargets[row], currentTargets[row - 1] = currentTargets[row - 1], currentTargets[row]
+                    currentTargetIds[row], currentTargetIds[row - 1] = currentTargetIds[row - 1], currentTargetIds[row]
 
                     self.targetsEditor:getDataSource():swapItems(IndexedItem.new(item1, selectedIndexPath), IndexedItem.new(item2, newIndexPath))
                     self.targetsEditor:getDelegate():selectItemAtIndexPath(newIndexPath)
@@ -140,26 +148,26 @@ function PullTargetsMenuItem:getMoveUpMenuItem()
                 end
             end
         end
-    end, "Targets", "Move selected target up in priority.", false, function()
+    end, "Target IDs", "Move selected target up in priority.", false, function()
         if not self.targetsEditor then return false end
         local cursorIndexPath = self.targetsEditor:getDelegate():getCursorIndexPath()
         return cursorIndexPath and cursorIndexPath.row > 1
     end)
 end
 
-function PullTargetsMenuItem:getMoveDownMenuItem()
+function PullTargetIDsMenuItem:getMoveDownMenuItem()
     return MenuItem.action(function()
         if self.targetsEditor then
             local selectedIndexPath = self.targetsEditor:getDelegate():getCursorIndexPath()
-            local currentTargets = self:getTargets()
-            if selectedIndexPath and selectedIndexPath.row < currentTargets:length() then
+            local currentTargetIds = self:getTargetIds()
+            if selectedIndexPath and selectedIndexPath.row < currentTargetIds:length() then
                 local row = selectedIndexPath.row
                 local newIndexPath = IndexPath.new(selectedIndexPath.section, row + 1)
 
                 local item1 = self.targetsEditor:getDataSource():itemAtIndexPath(selectedIndexPath)
                 local item2 = self.targetsEditor:getDataSource():itemAtIndexPath(newIndexPath)
                 if item1 and item2 then
-                    currentTargets[row], currentTargets[row + 1] = currentTargets[row + 1], currentTargets[row]
+                    currentTargetIds[row], currentTargetIds[row + 1] = currentTargetIds[row + 1], currentTargetIds[row]
 
                     self.targetsEditor:getDataSource():swapItems(IndexedItem.new(item1, selectedIndexPath), IndexedItem.new(item2, newIndexPath))
                     self.targetsEditor:getDelegate():selectItemAtIndexPath(newIndexPath)
@@ -168,12 +176,12 @@ function PullTargetsMenuItem:getMoveDownMenuItem()
                 end
             end
         end
-    end, "Targets", "Move selected target down in priority.", false, function()
+    end, "Target IDs", "Move selected target down in priority.", false, function()
         if not self.targetsEditor then return false end
         local cursorIndexPath = self.targetsEditor:getDelegate():getCursorIndexPath()
-        local currentTargets = self:getTargets()
-        return cursorIndexPath and cursorIndexPath.row < currentTargets:length()
+        local currentTargetIds = self:getTargetIds()
+        return cursorIndexPath and cursorIndexPath.row < currentTargetIds:length()
     end)
 end
 
-return PullTargetsMenuItem
+return PullTargetIDsMenuItem

--- a/ui/settings/menus/pulling/PullTargetIDsMenuItem.lua
+++ b/ui/settings/menus/pulling/PullTargetIDsMenuItem.lua
@@ -6,14 +6,13 @@ local IndexedItem = require('cylibs/ui/collection_view/indexed_item')
 local IndexPath = require('cylibs/ui/collection_view/index_path')
 local MenuItem = require('cylibs/ui/menu/menu_item')
 local MultiPickerConfigItem = require('ui/settings/editors/config/MultiPickerConfigItem')
+local PullTargetUtil = require('cylibs/util/pull_target_util')
 
 local PullTargetIDsMenuItem = setmetatable({}, {__index = MenuItem })
 PullTargetIDsMenuItem.__index = PullTargetIDsMenuItem
 
-local function format_target_id(targetId)
-    local mob = windower.ffxi.get_mob_by_id(targetId)
-    local targetName = mob and mob.name or "Unknown"
-    return string.format("%s (%X)", targetName, targetId)
+local function format_target_id(targetId, targetName)
+    return string.format("%s (%X)", targetName or "Unknown", targetId)
 end
 
 function PullTargetIDsMenuItem.new(trust_settings, trust_settings_mode)
@@ -35,10 +34,15 @@ function PullTargetIDsMenuItem.new(trust_settings, trust_settings_mode)
     self:setChildMenuItem("Move Down", self:getMoveDownMenuItem())
 
     self.contentViewConstructor = function()
-        local currentTargetIds = self:getTargetIds()
+        self:updateTargetNames()
 
-        local configItem = MultiPickerConfigItem.new("Target IDs", L{}, currentTargetIds, function(targetId)
-            return format_target_id(targetId)
+        local currentTargets = self:getTargets()
+
+        local configItem = MultiPickerConfigItem.new("Target IDs", L{}, self:getTargetIds(), function(targetId)
+            local target = currentTargets:firstWhere(function(t)
+                return PullTargetUtil.get_id(t) == targetId
+            end)
+            return format_target_id(targetId, PullTargetUtil.get_name(target))
         end)
 
         self.targetsEditor = FFXIPickerView.new(L{ configItem }, false, FFXIClassicStyle.WindowSize.Editor.ConfigEditor)
@@ -56,10 +60,40 @@ function PullTargetIDsMenuItem:destroy()
     self.dispose_bag:destroy()
 end
 
-function PullTargetIDsMenuItem:getTargetIds()
-    local pullSettings = self.trust_settings:getSettings()[self.trust_settings_mode.value].PullSettings
+function PullTargetIDsMenuItem:getPullSettings()
+    return self.trust_settings:getSettings()[self.trust_settings_mode.value].PullSettings
+end
+
+---
+-- Returns the targets to pull.
+--
+-- @treturn list Targets to pull.
+--
+function PullTargetIDsMenuItem:getTargets()
+    local pullSettings = self:getPullSettings()
     pullSettings.TargetIds = pullSettings.TargetIds or L{}
     return pullSettings.TargetIds
+end
+
+function PullTargetIDsMenuItem:getTargetIds()
+    return self:getTargets():map(PullTargetUtil.get_id)
+end
+
+---
+-- Updates the saved name of any target that's in the current zone, so the name
+-- still shows in the list after zoning away, when the mob can no longer be looked
+-- up by id.
+--
+function PullTargetIDsMenuItem:updateTargetNames()
+    local didUpdateNames = false
+
+    for target in self:getTargets():it() do
+        didUpdateNames = PullTargetUtil.update_name(target) or didUpdateNames
+    end
+
+    if didUpdateNames then
+        self.trust_settings:saveSettings(true)
+    end
 end
 
 function PullTargetIDsMenuItem:getAddMenuItem()
@@ -79,7 +113,7 @@ function PullTargetIDsMenuItem:getAddMenuItem()
         end
 
         local configItem = MultiPickerConfigItem.new("Target IDs", L{}, L(allTargetIds), function(targetId)
-            return format_target_id(targetId)
+            return format_target_id(targetId, PullTargetUtil.get_mob_name(targetId))
         end)
 
         local targetPickerView = FFXIPickerView.withConfig(configItem, true, FFXIClassicStyle.WindowSize.Editor.ConfigEditor)
@@ -88,8 +122,10 @@ function PullTargetIDsMenuItem:getAddMenuItem()
             targetPickerView:getDelegate():deselectAllItems()
 
             if newTargetIds:length() > 0 then
-                local pullSettings = self.trust_settings:getSettings()[self.trust_settings_mode.value].PullSettings
-                pullSettings.TargetIds = L(S(self:getTargetIds() + newTargetIds))
+                local newTargets = newTargetIds:map(function(targetId)
+                    return PullTargetUtil.new(targetId)
+                end)
+                self:getPullSettings().TargetIds = (self:getTargets() + newTargets):unique(PullTargetUtil.get_id)
 
                 self.trust_settings:saveSettings(true)
 
@@ -112,8 +148,8 @@ function PullTargetIDsMenuItem:getRemoveMenuItem()
         if self.targetsEditor then
             local cursorIndexPath = self.targetsEditor:getDelegate():getCursorIndexPath()
             if cursorIndexPath then
-                local currentTargetIds = self:getTargetIds()
-                currentTargetIds:remove(cursorIndexPath.row)
+                local currentTargets = self:getTargets()
+                currentTargets:remove(cursorIndexPath.row)
 
                 self.targetsEditor:getDataSource():removeItem(cursorIndexPath)
 
@@ -123,7 +159,7 @@ function PullTargetIDsMenuItem:getRemoveMenuItem()
             end
         end
     end, "Target IDs", "Remove selected target from list of enemies to pull.", false, function()
-        return self:getTargetIds():length() > 0
+        return self:getTargets():length() > 0
     end)
 end
 
@@ -132,14 +168,14 @@ function PullTargetIDsMenuItem:getMoveUpMenuItem()
         if self.targetsEditor then
             local selectedIndexPath = self.targetsEditor:getDelegate():getCursorIndexPath()
             if selectedIndexPath and selectedIndexPath.row > 1 then
-                local currentTargetIds = self:getTargetIds()
+                local currentTargets = self:getTargets()
                 local row = selectedIndexPath.row
                 local newIndexPath = IndexPath.new(selectedIndexPath.section, row - 1)
 
                 local item1 = self.targetsEditor:getDataSource():itemAtIndexPath(selectedIndexPath)
                 local item2 = self.targetsEditor:getDataSource():itemAtIndexPath(newIndexPath)
                 if item1 and item2 then
-                    currentTargetIds[row], currentTargetIds[row - 1] = currentTargetIds[row - 1], currentTargetIds[row]
+                    currentTargets[row], currentTargets[row - 1] = currentTargets[row - 1], currentTargets[row]
 
                     self.targetsEditor:getDataSource():swapItems(IndexedItem.new(item1, selectedIndexPath), IndexedItem.new(item2, newIndexPath))
                     self.targetsEditor:getDelegate():selectItemAtIndexPath(newIndexPath)
@@ -159,15 +195,15 @@ function PullTargetIDsMenuItem:getMoveDownMenuItem()
     return MenuItem.action(function()
         if self.targetsEditor then
             local selectedIndexPath = self.targetsEditor:getDelegate():getCursorIndexPath()
-            local currentTargetIds = self:getTargetIds()
-            if selectedIndexPath and selectedIndexPath.row < currentTargetIds:length() then
+            local currentTargets = self:getTargets()
+            if selectedIndexPath and selectedIndexPath.row < currentTargets:length() then
                 local row = selectedIndexPath.row
                 local newIndexPath = IndexPath.new(selectedIndexPath.section, row + 1)
 
                 local item1 = self.targetsEditor:getDataSource():itemAtIndexPath(selectedIndexPath)
                 local item2 = self.targetsEditor:getDataSource():itemAtIndexPath(newIndexPath)
                 if item1 and item2 then
-                    currentTargetIds[row], currentTargetIds[row + 1] = currentTargetIds[row + 1], currentTargetIds[row]
+                    currentTargets[row], currentTargets[row + 1] = currentTargets[row + 1], currentTargets[row]
 
                     self.targetsEditor:getDataSource():swapItems(IndexedItem.new(item1, selectedIndexPath), IndexedItem.new(item2, newIndexPath))
                     self.targetsEditor:getDelegate():selectItemAtIndexPath(newIndexPath)
@@ -179,8 +215,8 @@ function PullTargetIDsMenuItem:getMoveDownMenuItem()
     end, "Target IDs", "Move selected target down in priority.", false, function()
         if not self.targetsEditor then return false end
         local cursorIndexPath = self.targetsEditor:getDelegate():getCursorIndexPath()
-        local currentTargetIds = self:getTargetIds()
-        return cursorIndexPath and cursorIndexPath.row < currentTargetIds:length()
+        local currentTargets = self:getTargets()
+        return cursorIndexPath and cursorIndexPath.row < currentTargets:length()
     end)
 end
 


### PR DESCRIPTION
Adds a Migration_v40 to introduce a TargetIds pull setting alongside the existing Targets (by name) setting, a TargetIdsCondition, and a PullTargetIDsMenuItem for configuring it. Puller now matches mobs by name or ID when auto-pulling.